### PR TITLE
add vulnerability when using object keys as cache

### DIFF
--- a/vulnerabilities/proto_abuse.js
+++ b/vulnerabilities/proto_abuse.js
@@ -1,0 +1,19 @@
+// This is a very common exploit that used to exist in express
+// servers and plugins. It is based on how users of JavaScript abuse
+// objects as maps.
+function Cache() {
+}
+Cache.prototype.persist = function() {
+	var conn = "MY_SECRET_REDIS_KEY"
+	Object.keys(this).forEach(function(){
+		// code that stores properties in redis 
+	});
+}
+var e = require("express");
+var DVNA = e();
+var cache = new Cache(); // note this is not a Map.
+DVNA.get('/', function(req, res) {
+	res.send(cache[req.query.id].toString());
+	res.end();
+});
+DVNA.listen(1338);


### PR DESCRIPTION
This is a surprisingly common exploit when people use an object with behavior for a cache.

In this example the object has a persist method and toString'ing it does function#toString which shows the secret database key. 
