### PR TITLE
attack based on assumption __proto__ is not a member of the cache

### DIFF
--- a/vulnerabilities/__proto__crash.js
+++ b/vulnerabilities/__proto__crash.js
@@ -1,0 +1,22 @@
+// This is a very common exploit that used to exist in express itself
+// when sending __proto__ as a key to a cache the server would crash.
+
+var e = require("express");
+var DVNA = e();
+var numberCache = {}; // note this is not a Map
+DVNA.get('/', function(req, res) {
+	setTimeout(function(){ // simulate async action
+		if(req.query.id in numberCache) { // "sanitize", but fails for __proto__
+			res.send(numberCache[req.query.id].toFixed(2));
+		} else {
+			res.send("Not in cache");
+		}
+		res.end();
+	});
+});
+DVNA.get("/add", function(req, res) { //GET only to simplify the example. 
+	// the cache is typed, so we can expect all properties in it to
+	// have a `toFixed` method.
+	numberCache[req.query.key] = Number(req.query.value); 
+})
+DVNA.listen(1338);


### PR DESCRIPTION
This used to be a vulnerabilty in express itself at some point - a lot of sites still make this mistkae