### PR TITLE
Renamed variable to prevent response handler from being overwriten

### DIFF
--- a/vulnerabilities/eval_remote_code_execution/vulnerability.js
+++ b/vulnerabilities/eval_remote_code_execution/vulnerability.js
@@ -2,8 +2,8 @@ var express = require('express');
 var DVNA = express();
 
 DVNA.get('/evaluate', function(request, response) {
-  var response = eval("("+request.query.e+")");
-  response.send('Parameter eval():<br> ' + response);
+  var res = eval("("+request.query.e+")");
+  response.send('Parameter eval():<br> ' + res);
 });
 
 DVNA.get('/build_function', function(request, response) {


### PR DESCRIPTION
Eval RCE challenge uses the same name for two variables, hence overwriting one of them and breaking the challenge.